### PR TITLE
Update HPDevice.php

### DIFF
--- a/HPDevice.php
+++ b/HPDevice.php
@@ -399,7 +399,7 @@ abstract class HPDevice extends IPSModule {
 					SetValueInteger( $valuesId, $cmdpos );
 				}
 
-				$automatik = ($values['Manuellbetrieb'] == 0);
+				$automatik = (isset($data['Manuellbetrieb']) && $data['Manuellbetrieb'] == 0);
 				if (!$valuesId = @$this->GetIDForIdent("AUTOMATIC")) {
 					$valuesId = $this->RegisterVariableBoolean("AUTOMATIC", "Automatik", "~Switch", 10);
 					$this->EnableAction("AUTOMATIC");


### PR DESCRIPTION
Durch das Hinzufügen des HomePilot Zeitschaltuhr premium smart" kam es zu einen Fehler inZeile 402/3:

Warning: Undefined array key "Manuellbetrieb" in /var/lib/symcon/modules/SymconHP/HPDevice.php on line 403

Es scheint, dass das Problem mit dem Zugriff auf einen nicht existierenden Schlüssel im Array $data zusammenhängt. In Ihrem Skript versuchen Sie, auf den Schlüssel Manuellbetrieb in diesem Array zuzugreifen, aber es sieht so aus, als ob dieser Schlüssel für Ihr neues Gerät nicht vorhanden oder nicht gesetzt ist.

Die Fehlermeldung "Undefined array key" tritt auf, wenn Sie versuchen, auf einen Array-Schlüssel zuzugreifen, der nicht existiert. Um diesen Fehler zu beheben, sollten Sie überprüfen, ob der Schlüssel im Array existiert, bevor Sie darauf zugreifen. Sie können dies mit der PHP-Funktion array_key_exists oder einer isset-Prüfung tun.
------------

Bei mir funktioniert es jetzt ohne Fehler. Ob das so korrekt ist kann ich, als jemand der nicht coden kann, nicht sagen.